### PR TITLE
Increase resilience for getting .jar files and parallelize analysing of .jar files

### DIFF
--- a/Form1.Designer.cs
+++ b/Form1.Designer.cs
@@ -22,7 +22,8 @@
     /// Required method for Designer support - do not modify
     /// the contents of this method with the code editor.
     /// </summary>
-    private void InitializeComponent() {
+    private void InitializeComponent()
+    {
       this.groupBox1 = new System.Windows.Forms.GroupBox();
       this.buttonBrowse = new System.Windows.Forms.Button();
       this.textBoxFolderFile = new System.Windows.Forms.TextBox();
@@ -35,22 +36,22 @@
       this.textBoxDetections = new System.Windows.Forms.TextBox();
       this.progressBar = new System.Windows.Forms.ProgressBar();
       this.labelStatus = new System.Windows.Forms.Label();
+      this.errorBox = new System.Windows.Forms.GroupBox();
+      this.errorTextBox = new System.Windows.Forms.TextBox();
       this.groupBox1.SuspendLayout();
       this.groupBox2.SuspendLayout();
       this.groupBox3.SuspendLayout();
+      this.errorBox.SuspendLayout();
       this.SuspendLayout();
       // 
       // groupBox1
       // 
-      this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
+      this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
       this.groupBox1.Controls.Add(this.buttonBrowse);
       this.groupBox1.Controls.Add(this.textBoxFolderFile);
-      this.groupBox1.Location = new System.Drawing.Point(10, 17);
-      this.groupBox1.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+      this.groupBox1.Location = new System.Drawing.Point(15, 26);
       this.groupBox1.Name = "groupBox1";
-      this.groupBox1.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
-      this.groupBox1.Size = new System.Drawing.Size(1017, 48);
+      this.groupBox1.Size = new System.Drawing.Size(1526, 74);
       this.groupBox1.TabIndex = 0;
       this.groupBox1.TabStop = false;
       this.groupBox1.Text = "Folder/File:";
@@ -58,10 +59,9 @@
       // buttonBrowse
       // 
       this.buttonBrowse.Anchor = System.Windows.Forms.AnchorStyles.Right;
-      this.buttonBrowse.Location = new System.Drawing.Point(956, 18);
-      this.buttonBrowse.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+      this.buttonBrowse.Location = new System.Drawing.Point(1434, 28);
       this.buttonBrowse.Name = "buttonBrowse";
-      this.buttonBrowse.Size = new System.Drawing.Size(56, 21);
+      this.buttonBrowse.Size = new System.Drawing.Size(84, 32);
       this.buttonBrowse.TabIndex = 1;
       this.buttonBrowse.Text = "Browse";
       this.buttonBrowse.UseVisualStyleBackColor = true;
@@ -70,22 +70,19 @@
       // textBoxFolderFile
       // 
       this.textBoxFolderFile.AllowDrop = true;
-      this.textBoxFolderFile.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-      this.textBoxFolderFile.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-      this.textBoxFolderFile.Location = new System.Drawing.Point(5, 18);
-      this.textBoxFolderFile.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+      this.textBoxFolderFile.Anchor = ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+      this.textBoxFolderFile.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
+      this.textBoxFolderFile.Location = new System.Drawing.Point(8, 28);
       this.textBoxFolderFile.Name = "textBoxFolderFile";
-      this.textBoxFolderFile.Size = new System.Drawing.Size(947, 23);
+      this.textBoxFolderFile.Size = new System.Drawing.Size(1418, 30);
       this.textBoxFolderFile.TabIndex = 0;
       this.textBoxFolderFile.DragDrop += new System.Windows.Forms.DragEventHandler(this.textBoxFolderFile_DragDrop);
       // 
       // buttonScan
       // 
-      this.buttonScan.Location = new System.Drawing.Point(9, 76);
-      this.buttonScan.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+      this.buttonScan.Location = new System.Drawing.Point(14, 117);
       this.buttonScan.Name = "buttonScan";
-      this.buttonScan.Size = new System.Drawing.Size(62, 27);
+      this.buttonScan.Size = new System.Drawing.Size(93, 42);
       this.buttonScan.TabIndex = 1;
       this.buttonScan.Text = "Scan";
       this.buttonScan.UseVisualStyleBackColor = true;
@@ -93,51 +90,43 @@
       // 
       // groupBox2
       // 
-      this.groupBox2.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
+      this.groupBox2.Anchor = ((System.Windows.Forms.AnchorStyles) ((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
       this.groupBox2.Controls.Add(this.textBoxOutput);
-      this.groupBox2.Location = new System.Drawing.Point(15, 108);
-      this.groupBox2.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+      this.groupBox2.Location = new System.Drawing.Point(22, 165);
       this.groupBox2.Name = "groupBox2";
-      this.groupBox2.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
-      this.groupBox2.Size = new System.Drawing.Size(505, 309);
+      this.groupBox2.Size = new System.Drawing.Size(758, 792);
       this.groupBox2.TabIndex = 2;
       this.groupBox2.TabStop = false;
       this.groupBox2.Text = "Output:";
       // 
       // textBoxOutput
       // 
-      this.textBoxOutput.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-      this.textBoxOutput.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-      this.textBoxOutput.Location = new System.Drawing.Point(5, 18);
-      this.textBoxOutput.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+      this.textBoxOutput.Anchor = ((System.Windows.Forms.AnchorStyles) ((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+      this.textBoxOutput.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
+      this.textBoxOutput.Location = new System.Drawing.Point(8, 28);
       this.textBoxOutput.Multiline = true;
       this.textBoxOutput.Name = "textBoxOutput";
       this.textBoxOutput.ReadOnly = true;
       this.textBoxOutput.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-      this.textBoxOutput.Size = new System.Drawing.Size(492, 277);
+      this.textBoxOutput.Size = new System.Drawing.Size(736, 357);
       this.textBoxOutput.TabIndex = 0;
       // 
       // statusStrip1
       // 
       this.statusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
-      this.statusStrip1.Location = new System.Drawing.Point(0, 415);
+      this.statusStrip1.Location = new System.Drawing.Point(0, 966);
       this.statusStrip1.Name = "statusStrip1";
-      this.statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 10, 0);
-      this.statusStrip1.Size = new System.Drawing.Size(1040, 22);
+      this.statusStrip1.Padding = new System.Windows.Forms.Padding(2, 0, 15, 0);
+      this.statusStrip1.Size = new System.Drawing.Size(1560, 22);
       this.statusStrip1.TabIndex = 3;
       this.statusStrip1.Text = "statusStrip1";
       // 
       // buttonClearOutput
       // 
-      this.buttonClearOutput.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-      this.buttonClearOutput.Location = new System.Drawing.Point(966, 76);
-      this.buttonClearOutput.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+      this.buttonClearOutput.Anchor = ((System.Windows.Forms.AnchorStyles) ((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+      this.buttonClearOutput.Location = new System.Drawing.Point(1449, 117);
       this.buttonClearOutput.Name = "buttonClearOutput";
-      this.buttonClearOutput.Size = new System.Drawing.Size(62, 27);
+      this.buttonClearOutput.Size = new System.Drawing.Size(93, 42);
       this.buttonClearOutput.TabIndex = 4;
       this.buttonClearOutput.Text = "Clear";
       this.buttonClearOutput.UseVisualStyleBackColor = true;
@@ -145,57 +134,73 @@
       // 
       // groupBox3
       // 
-      this.groupBox3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Right)));
+      this.groupBox3.Anchor = ((System.Windows.Forms.AnchorStyles) (((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Right)));
       this.groupBox3.Controls.Add(this.textBoxDetections);
-      this.groupBox3.Location = new System.Drawing.Point(524, 108);
-      this.groupBox3.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+      this.groupBox3.Location = new System.Drawing.Point(786, 165);
       this.groupBox3.Name = "groupBox3";
-      this.groupBox3.Padding = new System.Windows.Forms.Padding(2, 2, 2, 2);
-      this.groupBox3.Size = new System.Drawing.Size(506, 309);
+      this.groupBox3.Size = new System.Drawing.Size(759, 792);
       this.groupBox3.TabIndex = 5;
       this.groupBox3.TabStop = false;
       this.groupBox3.Text = "Infected files:";
       // 
       // textBoxDetections
       // 
-      this.textBoxDetections.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-      this.textBoxDetections.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+      this.textBoxDetections.Anchor = ((System.Windows.Forms.AnchorStyles) ((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+      this.textBoxDetections.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
       this.textBoxDetections.ForeColor = System.Drawing.Color.Red;
-      this.textBoxDetections.Location = new System.Drawing.Point(4, 18);
-      this.textBoxDetections.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+      this.textBoxDetections.Location = new System.Drawing.Point(6, 28);
       this.textBoxDetections.Multiline = true;
       this.textBoxDetections.Name = "textBoxDetections";
       this.textBoxDetections.ReadOnly = true;
       this.textBoxDetections.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-      this.textBoxDetections.Size = new System.Drawing.Size(494, 277);
+      this.textBoxDetections.Size = new System.Drawing.Size(739, 764);
       this.textBoxDetections.TabIndex = 1;
       // 
       // progressBar
       // 
-      this.progressBar.Location = new System.Drawing.Point(92, 80);
-      this.progressBar.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
+      this.progressBar.Location = new System.Drawing.Point(138, 123);
       this.progressBar.Name = "progressBar";
-      this.progressBar.Size = new System.Drawing.Size(517, 16);
+      this.progressBar.Size = new System.Drawing.Size(776, 25);
       this.progressBar.TabIndex = 6;
       // 
       // labelStatus
       // 
       this.labelStatus.AutoSize = true;
-      this.labelStatus.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-      this.labelStatus.Location = new System.Drawing.Point(622, 80);
-      this.labelStatus.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
+      this.labelStatus.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
+      this.labelStatus.Location = new System.Drawing.Point(933, 123);
       this.labelStatus.Name = "labelStatus";
-      this.labelStatus.Size = new System.Drawing.Size(0, 17);
+      this.labelStatus.Size = new System.Drawing.Size(0, 25);
       this.labelStatus.TabIndex = 7;
+      // 
+      // errorBox
+      // 
+      this.errorBox.Anchor = ((System.Windows.Forms.AnchorStyles) ((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+      this.errorBox.Controls.Add(this.errorTextBox);
+      this.errorBox.Location = new System.Drawing.Point(22, 566);
+      this.errorBox.Name = "errorBox";
+      this.errorBox.Size = new System.Drawing.Size(758, 391);
+      this.errorBox.TabIndex = 3;
+      this.errorBox.TabStop = false;
+      this.errorBox.Text = "Error:";
+      // 
+      // errorTextBox
+      // 
+      this.errorTextBox.Anchor = ((System.Windows.Forms.AnchorStyles) ((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) | System.Windows.Forms.AnchorStyles.Left) | System.Windows.Forms.AnchorStyles.Right)));
+      this.errorTextBox.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte) (0)));
+      this.errorTextBox.Location = new System.Drawing.Point(8, 28);
+      this.errorTextBox.Multiline = true;
+      this.errorTextBox.Name = "errorTextBox";
+      this.errorTextBox.ReadOnly = true;
+      this.errorTextBox.ScrollBars = System.Windows.Forms.ScrollBars.Both;
+      this.errorTextBox.Size = new System.Drawing.Size(736, 357);
+      this.errorTextBox.TabIndex = 0;
       // 
       // Form1
       // 
-      this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+      this.AutoScaleDimensions = new System.Drawing.SizeF(9F, 20F);
       this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-      this.ClientSize = new System.Drawing.Size(1040, 437);
+      this.ClientSize = new System.Drawing.Size(1560, 988);
+      this.Controls.Add(this.errorBox);
       this.Controls.Add(this.labelStatus);
       this.Controls.Add(this.progressBar);
       this.Controls.Add(this.groupBox3);
@@ -204,8 +209,7 @@
       this.Controls.Add(this.groupBox2);
       this.Controls.Add(this.buttonScan);
       this.Controls.Add(this.groupBox1);
-      this.Margin = new System.Windows.Forms.Padding(2, 2, 2, 2);
-      this.MinimumSize = new System.Drawing.Size(735, 476);
+      this.MinimumSize = new System.Drawing.Size(1092, 702);
       this.Name = "Form1";
       this.Text = "Jar Malware Scanner";
       this.groupBox1.ResumeLayout(false);
@@ -214,10 +218,14 @@
       this.groupBox2.PerformLayout();
       this.groupBox3.ResumeLayout(false);
       this.groupBox3.PerformLayout();
+      this.errorBox.ResumeLayout(false);
+      this.errorBox.PerformLayout();
       this.ResumeLayout(false);
       this.PerformLayout();
-
     }
+
+    private System.Windows.Forms.GroupBox errorBox;
+    private System.Windows.Forms.TextBox errorTextBox;
 
     #endregion
 

--- a/Form1.cs
+++ b/Form1.cs
@@ -3,26 +3,51 @@ using Microsoft.WindowsAPICodePack.Dialogs;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 
-namespace JarInfectionScanner {
-  public partial class Form1 : Form {
-    static List<byte[]> kSignatures = new List<byte[]>() {
-    new byte[] { 0x38, 0x54, 0x59, 0x04, 0x10, 0x35, 0x54, 0x59, 0x05, 0x10, 0x2E, 0x54, 0x59, 0x06, 0x10, 0x32, 0x54, 0x59, 0x07, 0x10, 0x31, 0x54, 0x59, 0x08, 0x10, 0x37, 0x54, 0x59, 0x10, 0x06, 0x10, 0x2E, 0x54, 0x59, 0x10, 0x07, 0x10, 0x31, 0x54, 0x59, 0x10, 0x08, 0x10, 0x34, 0x54, 0x59, 0x10, 0x09, 0x10, 0x34, 0x54, 0x59, 0x10, 0x0A, 0x10, 0x2E, 0x54, 0x59, 0x10, 0x0B, 0x10, 0x31, 0x54, 0x59, 0x10, 0x0C, 0x10, 0x33, 0x54, 0x59, 0x10, 0x0D, 0x10, 0x30, 0x54, 0xB7 },
-    new byte[] { 0x68, 0x54, 0x59, 0x04, 0x10, 0x74, 0x54, 0x59, 0x05, 0x10, 0x74, 0x54, 0x59, 0x06, 0x10, 0x70, 0x54, 0x59, 0x07, 0x10, 0x3a, 0x54, 0x59, 0x08, 0x10, 0x2f, 0x54, 0x59, 0x10, 0x06, 0x10, 0x2f, 0x54, 0x59, 0x10, 0x07, 0x10, 0x66, 0x54, 0x59, 0x10, 0x08, 0x10, 0x69, 0x54, 0x59, 0x10, 0x09, 0x10, 0x6c, 0x54, 0x59, 0x10, 0x0a, 0x10, 0x65, 0x54, 0x59, 0x10, 0x0b, 0x10, 0x73, 0x54, 0x59, 0x10, 0x0c, 0x10, 0x2e, 0x54, 0x59, 0x10, 0x0a, 0x10, 0x73, 0x54, 0x59, 0x10, 0x0e, 0x10, 0x6b, 0x54, 0x59, 0x10, 0x0f, 0x10, 0x79, 0x54, 0x59, 0x10, 0x10, 0x10, 0x72, 0x54, 0x59, 0x10, 0x11, 0x10, 0x61, 0x54, 0x59, 0x10, 0x12, 0x10, 0x67, 0x54, 0x59, 0x10, 0x13, 0x10, 0x65, 0x54, 0x59, 0x10, 0x14, 0x10, 0x2e, 0x54, 0x59, 0x10, 0x15, 0x10, 0x64 },
-    new byte[] { 0x2d, 0x54, 0x59, 0x04, 0x10, 0x6a, 0x54, 0x59, 0x05, 0x10, 0x61, 0x54, 0x59, 0x06, 0x10, 0x72 }
-  };
+namespace JarInfectionScanner
+{
+  public partial class Form1 : Form
+  {
+    static readonly IReadOnlyList<byte[]> kSignatures = new List<byte[]>
+    {
+      new byte[]
+      {
+        0x38, 0x54, 0x59, 0x04, 0x10, 0x35, 0x54, 0x59, 0x05, 0x10, 0x2E, 0x54, 0x59, 0x06, 0x10, 0x32, 0x54, 0x59,
+        0x07, 0x10, 0x31, 0x54, 0x59, 0x08, 0x10, 0x37, 0x54, 0x59, 0x10, 0x06, 0x10, 0x2E, 0x54, 0x59, 0x10, 0x07,
+        0x10, 0x31, 0x54, 0x59, 0x10, 0x08, 0x10, 0x34, 0x54, 0x59, 0x10, 0x09, 0x10, 0x34, 0x54, 0x59, 0x10, 0x0A,
+        0x10, 0x2E, 0x54, 0x59, 0x10, 0x0B, 0x10, 0x31, 0x54, 0x59, 0x10, 0x0C, 0x10, 0x33, 0x54, 0x59, 0x10, 0x0D,
+        0x10, 0x30, 0x54, 0xB7
+      },
+      new byte[]
+      {
+        0x68, 0x54, 0x59, 0x04, 0x10, 0x74, 0x54, 0x59, 0x05, 0x10, 0x74, 0x54, 0x59, 0x06, 0x10, 0x70, 0x54, 0x59,
+        0x07, 0x10, 0x3a, 0x54, 0x59, 0x08, 0x10, 0x2f, 0x54, 0x59, 0x10, 0x06, 0x10, 0x2f, 0x54, 0x59, 0x10, 0x07,
+        0x10, 0x66, 0x54, 0x59, 0x10, 0x08, 0x10, 0x69, 0x54, 0x59, 0x10, 0x09, 0x10, 0x6c, 0x54, 0x59, 0x10, 0x0a,
+        0x10, 0x65, 0x54, 0x59, 0x10, 0x0b, 0x10, 0x73, 0x54, 0x59, 0x10, 0x0c, 0x10, 0x2e, 0x54, 0x59, 0x10, 0x0a,
+        0x10, 0x73, 0x54, 0x59, 0x10, 0x0e, 0x10, 0x6b, 0x54, 0x59, 0x10, 0x0f, 0x10, 0x79, 0x54, 0x59, 0x10, 0x10,
+        0x10, 0x72, 0x54, 0x59, 0x10, 0x11, 0x10, 0x61, 0x54, 0x59, 0x10, 0x12, 0x10, 0x67, 0x54, 0x59, 0x10, 0x13,
+        0x10, 0x65, 0x54, 0x59, 0x10, 0x14, 0x10, 0x2e, 0x54, 0x59, 0x10, 0x15, 0x10, 0x64
+      },
+      new byte[] {0x2d, 0x54, 0x59, 0x04, 0x10, 0x6a, 0x54, 0x59, 0x05, 0x10, 0x61, 0x54, 0x59, 0x06, 0x10, 0x72}
+    };
 
-    public Form1() {
+    public Form1()
+    {
       InitializeComponent();
     }
 
-    private void textBoxFolderFile_DragDrop(object sender, DragEventArgs e) {
+    private void textBoxFolderFile_DragDrop(object sender, DragEventArgs e)
+    {
     }
 
-    private async void buttonScan_Click(object sender, EventArgs e) {
-      if (textBoxFolderFile.Text.Length == 0) {
+    private async void buttonScan_Click(object sender, EventArgs e)
+    {
+      if (textBoxFolderFile.Text.Length == 0)
+      {
         textBoxFolderFile.Focus();
         return;
       }
@@ -35,100 +60,196 @@ namespace JarInfectionScanner {
       progressBar.Value = 0;
       labelStatus.Text = "";
 
-      try {
-        await Task.Run(() => {
+      try
+      {
+        // We want to maximize parallelized scanning, but we don't want to overload the system, so we try to use 75% of the available processors.
+        int processorCount = (int)Math.Max(Math.Floor(Environment.ProcessorCount * 0.75), 1);
+        SemaphoreSlim semaphore = new SemaphoreSlim(processorCount, processorCount);
+        
+        await Task.Run(async () =>
+        {
           AddOutputLine("Searching for files (this may take a while) ...");
 
-          string[] jarFiles =
-            Directory.GetFiles(directory, "*.jar", SearchOption.AllDirectories);
+          string[] jarFiles = GetJarFiles(directory).ToArray();
 
           int detectionsFound = 0;
 
-          for (int i = 0; i < jarFiles.Length; ++i) {
-            string jarFile = jarFiles[i];
-            AddOutputLine($"[{i + 1}/{jarFiles.Length}] Scanning {jarFile} ...");
-
-            if (CheckJarFile(jarFile)) {
-              detectionsFound++;
-            }
-
-            this.BeginInvoke(new Action(() => {
-              progressBar.Value = (int)Math.Floor((i/(float)jarFiles.Length)*100);
-            }));
+          List<Task> tasks = new List<Task>();
+          long i = 1;
+          foreach (string jarFile in jarFiles)
+          {
+              tasks.Add(Task.Run(async () =>
+              {
+                try
+                {
+                  await semaphore.WaitAsync();
+                  AddOutputLine($"[{Interlocked.Increment(ref i)}/{jarFiles.Length}] Scanning {jarFile} ...");
+                  
+                  if (await CheckJarFileAsync(jarFile).ConfigureAwait(false))
+                  {
+                    Interlocked.Increment(ref detectionsFound);
+                  }
+                } finally
+                {
+                  semaphore.Release();
+                }
+                
+                this.BeginInvoke(new Action(() => {
+                  progressBar.Value = (int)Math.Floor((Interlocked.Read(ref i)-1)/(float)jarFiles.Length*100);
+                }));
+              }));
           }
-
+          
+          await Task.WhenAll(tasks);
+          
           AddOutputLine("Scan Complete");
 
-          this.BeginInvoke(new Action(() => {
-            if (detectionsFound > 0) {
+          this.BeginInvoke(new Action(() =>
+          {
+            if (detectionsFound > 0)
+            {
               labelStatus.Text = $"Scan complete - found {detectionsFound} infected files";
-            } else {
+            } else
+            {
               labelStatus.Text = $"Scan complete - no infected files found";
             }
           }));
         });
-      } catch (Exception ex) {
-        AddOutputLine(ex.ToString());
-      } finally {
+      } catch (Exception ex)
+      {
+        AddErrorLine(ex.ToString());
+      }
+      finally
+      {
         buttonScan.Enabled = true;
         buttonClearOutput.Enabled = true;
       }
     }
 
-    private void buttonBrowse_Click(object sender, EventArgs e) {
-      var dialog = new CommonOpenFileDialog {
+    private IEnumerable<string> GetJarFiles(string directory, HashSet<string> alreadySearched = null)
+    {
+      alreadySearched = alreadySearched ?? new HashSet<string>();
+      
+      try
+      {
+        // We don't want to search the same directory twice, so we resolve the final path name and check if we've already searched it
+        // This is to prevent infinite loops when there are symbolic links
+        string finalPathName = NativeMethods.GetFinalPathName(directory);
+        if (!alreadySearched.Add(finalPathName))
+        {
+          yield break;
+        }
+      }catch
+      {
+        AddErrorLine($"Failed to resolve '{directory}' to a final path name - skipping directory");
+      }
+      
+      string[] files;
+      try
+      {
+        files = Directory.GetFiles(directory, "*.jar");
+      } catch
+      {
+        files = Array.Empty<string>();
+        AddErrorLine($"Failed to get files in directory '{directory}'");
+      }
+      
+      foreach (string file in files)
+      {
+        yield return file;
+      }
+      
+      string[] directories;
+      try
+      {
+        directories = Directory.GetDirectories(directory);
+      } catch
+      {
+        directories = Array.Empty<string>();
+        AddErrorLine($"Failed to get directories in directory '{directory}'");
+      }
+
+      foreach (string subDirectory in directories)
+      {
+        foreach (string file in GetJarFiles(subDirectory, alreadySearched))
+        {
+          yield return file;
+        }
+      }
+      
+    }
+
+    private void buttonBrowse_Click(object sender, EventArgs e)
+    {
+      CommonOpenFileDialog dialog = new CommonOpenFileDialog
+      {
         IsFolderPicker = true,
         Title = "Select a Folder"
       };
 
-      if (dialog.ShowDialog() == CommonFileDialogResult.Ok) {
+      if (dialog.ShowDialog() == CommonFileDialogResult.Ok)
+      {
         textBoxFolderFile.Text = dialog.FileName;
       }
     }
 
-    private void buttonClearOutput_Click(object sender, EventArgs e) {
+    private void buttonClearOutput_Click(object sender, EventArgs e)
+    {
       ClearOutputs();
     }
 
-    private void ClearOutputs() {
+    private void ClearOutputs()
+    {
       textBoxOutput.Clear();
       textBoxDetections.Clear();
     }
 
-    private void AddOutputLine(string outputLine) {
-      this.BeginInvoke(new Action(() => {
+    private void AddOutputLine(string outputLine)
+    {
+      this.BeginInvoke(new Action(() =>
+      {
         textBoxOutput.AppendText(outputLine + Environment.NewLine);
         textBoxOutput.SelectionStart = textBoxOutput.Text.Length;
         textBoxOutput.ScrollToCaret();
       }));
     }
 
-    private void AddDetectionLine(string outputLine) {
-      this.BeginInvoke(new Action(() => {
+    private void AddDetectionLine(string outputLine)
+    {
+      this.BeginInvoke(new Action(() =>
+      {
         textBoxDetections.AppendText(outputLine + Environment.NewLine);
         textBoxDetections.SelectionStart = textBoxOutput.Text.Length;
         textBoxDetections.ScrollToCaret();
       }));
     }
 
-    bool CheckJarFile(string jarFilePath) {
-      try {
-        using (var jarFile = new ZipFile(jarFilePath)) {
-          foreach (ZipEntry entry in jarFile) {
-            if (!entry.IsFile || !entry.Name.EndsWith(".class")) {
+    async Task<bool> CheckJarFileAsync(string jarFilePath)
+    {
+      try
+      {
+        using (ZipFile jarFile = new ZipFile(jarFilePath))
+        {
+          foreach (ZipEntry entry in jarFile)
+          {
+            if (!entry.IsFile || !entry.Name.EndsWith(".class"))
+            {
               continue;
             }
 
-            using (var zipStream = jarFile.GetInputStream(entry)) {
+            using (Stream zipStream = jarFile.GetInputStream(entry))
+            {
               byte[] buffer = new byte[entry.Size];
 
               // TODO: Conversion might fail for large files - fix to read
               // in a while loop
-              zipStream.Read(buffer, 0, (int)entry.Size);
+              await zipStream.ReadAsync(buffer, 0, (int)entry.Size).ConfigureAwait(false);
 
-              foreach (byte[] sequence in kSignatures) {
+              foreach (byte[] sequence in kSignatures)
+              {
                 // if (ContainsByteArray(buffer, sequence)) {
-                if (QuickBinaryFind.FindByteSubstring(buffer, sequence) != -1) {
+                if (QuickBinaryFind.FindByteSubstring(buffer, sequence) != -1)
+                {
                   string line = $"!!!!{jarFilePath} is infected" + Environment.NewLine;
                   AddOutputLine(line);
                   AddDetectionLine(line);
@@ -138,11 +259,22 @@ namespace JarInfectionScanner {
             }
           }
         }
-      } catch (Exception ex) {
-        AddOutputLine($"Error while extracting {jarFilePath}: {ex.Message}");
+      } catch (Exception ex)
+      {
+        AddErrorLine($"Error while extracting {jarFilePath}: {ex.Message}");
       }
 
       return false;
+    }
+
+    private void AddErrorLine(string error)
+    {
+      this.BeginInvoke(new Action(() =>
+      {
+        errorTextBox.AppendText(error + Environment.NewLine);
+        errorTextBox.SelectionStart = textBoxOutput.Text.Length;
+        errorTextBox.ScrollToCaret();
+      }));
     }
   }
 }

--- a/Form1.cs
+++ b/Form1.cs
@@ -75,7 +75,7 @@ namespace JarInfectionScanner
           int detectionsFound = 0;
 
           List<Task> tasks = new List<Task>();
-          long i = 1;
+          long i = 0;
           foreach (string jarFile in jarFiles)
           {
               tasks.Add(Task.Run(async () =>
@@ -95,7 +95,7 @@ namespace JarInfectionScanner
                 }
                 
                 this.BeginInvoke(new Action(() => {
-                  progressBar.Value = (int)Math.Floor((Interlocked.Read(ref i)-1)/(float)jarFiles.Length*100);
+                  progressBar.Value = (int)Math.Floor(Interlocked.Read(ref i)/(float)jarFiles.Length*100);
                 }));
               }));
           }

--- a/JarInfectionScanner.csproj
+++ b/JarInfectionScanner.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Form1.Designer.cs">
       <DependentUpon>Form1.cs</DependentUpon>
     </Compile>
+    <Compile Include="NativeMethods.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="QuickBinaryFind.cs" />

--- a/NativeMethods.cs
+++ b/NativeMethods.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.ComponentModel;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace JarInfectionScanner
+{
+  // https://stackoverflow.com/a/33487494
+  public static class NativeMethods
+  {
+    private static readonly IntPtr INVALID_HANDLE_VALUE = new IntPtr(-1);
+
+    private const uint FILE_READ_EA = 0x0008;
+    private const uint FILE_FLAG_BACKUP_SEMANTICS = 0x2000000;
+
+    [DllImport("Kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    static extern uint GetFinalPathNameByHandle(IntPtr hFile, [MarshalAs(UnmanagedType.LPTStr)] StringBuilder lpszFilePath, uint cchFilePath, uint dwFlags);
+
+    [DllImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    static extern bool CloseHandle(IntPtr hObject);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    public static extern IntPtr CreateFile(
+      [MarshalAs(UnmanagedType.LPTStr)] string filename,
+      [MarshalAs(UnmanagedType.U4)] uint access,
+      [MarshalAs(UnmanagedType.U4)] FileShare share,
+      IntPtr securityAttributes, // optional SECURITY_ATTRIBUTES struct or IntPtr.Zero
+      [MarshalAs(UnmanagedType.U4)] FileMode creationDisposition,
+      [MarshalAs(UnmanagedType.U4)] uint flagsAndAttributes,
+      IntPtr templateFile);
+
+    public static string GetFinalPathName(string path)
+    {
+      IntPtr h = CreateFile(path, 
+        FILE_READ_EA, 
+        FileShare.ReadWrite | FileShare.Delete, 
+        IntPtr.Zero, 
+        FileMode.Open, 
+        FILE_FLAG_BACKUP_SEMANTICS,
+        IntPtr.Zero);
+      if (h == INVALID_HANDLE_VALUE)
+        throw new Win32Exception();
+
+      try
+      {
+        StringBuilder sb = new StringBuilder(1024);
+        uint res = GetFinalPathNameByHandle(h, sb, 1024, 0);
+        if (res == 0)
+          throw new Win32Exception();
+
+        return sb.ToString();
+      }
+      finally
+      {
+        CloseHandle(h);
+      }
+    }
+  }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace JarInfectionScanner {


### PR DESCRIPTION
In this PR I have improved the resilience in getting the list of jar files. In the current version listing the jar files fails on the for folder which cannot be loaded. This causes the problem, that you cannot use this program on a whole drive usually.

Additionally to that I have parallelized the analysing of .jar files. This improves the speed of analysing the files.

Also I added an additional error output.